### PR TITLE
Added --diggest to the docker images command, as it's helpful to get …

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -184,7 +184,7 @@ get_docker(){
 
 	print_msg "Grabbing docker images..." "INFO"
 	# output of docker info
-	docker images --all > $docker_folder/images.txt 2>&1
+	docker images --all --digests > $docker_folder/images.txt 2>&1
 
 	i=5
 	print_msg "Grabbing $i repeated container stats..." "INFO"


### PR DESCRIPTION
…the checksums of the images.
I.e. sometimes in offline installs the images are tagged wrong and thus causing bootloops. 