### PR TITLE
limit docker logs to last 72 hours

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -21,7 +21,7 @@ create_folders(){
 	while :; do
         	case $1 in
         		system)
-			mkdir -p $elastic_folder                
+			mkdir -p $elastic_folder
 			;;
 			docker)
 			mkdir -p $docker_logs_folder
@@ -38,7 +38,7 @@ create_folders(){
             		--) # End of all options.
             		shift
 			break
-			;;	
+			;;
 			*) # Default case: No more options, so break out of the loop.
                 	break
 		esac
@@ -48,14 +48,14 @@ create_folders(){
 
 clean(){
 	print_msg "Cleaning temp files..." "INFO"
-	rm -rf $diag_folder	
+	rm -rf $diag_folder
 }
 
 
 
 
 create_archive(){
-	
+
 	if [ -d $diag_folder ]
 		then
 			print_msg "Compressing diag file..." "INFO"
@@ -92,9 +92,9 @@ show_help(){
 	echo "Sample usage:"
 	echo "\"./diagnostics.sh -d -s\" #collects system and docker level info"
 	echo "\"./diagnostics.sh -a -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects allocators information"
-	echo "\"./diagnostics.sh -e 192.168.1.42 -x 12409 -a -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects allocators information using custom host and port" 
+	echo "\"./diagnostics.sh -e 192.168.1.42 -x 12409 -a -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects allocators information using custom host and port"
 	echo "\"./diagnostics.sh -c e817ac5fbc674aeab132500a263eca71 -d -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects cluster plan,info and docker info only for the specified cluster ID"
-	echo "\"./diagnostics.sh -c e817ac5fbc674aeab132500a263eca71 -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects cluster plan,info for the specified cluster ID" 
+	echo "\"./diagnostics.sh -c e817ac5fbc674aeab132500a263eca71 -u readonly -p oRXdD2tsLrEDelIF4iFAB6RlRzK6Rjxk3E4qTg27Ynj\" #collects cluster plan,info for the specified cluster ID"
 	echo ""
 }
 
@@ -142,7 +142,7 @@ get_system(){
 			#memory - sample 5 times every 1 second
 			print_msg "SAR [sampling memory usage]" "INFO"
 			sar -r 1 5 > $elastic_folder/sar_memory_sampled.txt 2>&1
-			#swap - sample once 
+			#swap - sample once
 			print_msg "SAR [collect swap usage]" "INFO"
 			sar -S 1 1 > $elastic_folder/sar_swap_sampled.txt 2>&1
 			#network
@@ -150,7 +150,7 @@ get_system(){
 			sar -n DEV > $elastic_folder/sar_network.txt 2>&1
 		else
 			print_msg "'sar' command not found. Please install package 'sysstat' to collect extended system stats" "WARN"
-	fi 
+	fi
 	print_msg "Grabbing ECE logs" "INFO"
 	cd $storage_path && find . -type f -name *.log -exec cp --parents \{\} $elastic_folder \;
 	print_msg "Checking XFS info" "INFO"
@@ -162,20 +162,20 @@ get_docker(){
 		#clusterId is passed as argument - filter on it
 		then
 			containersId=(`docker ps -a --format "{{.ID}}" --filter="name=$1" `)
-        		logNames=(`docker ps -a --format "{{.ID}}__{{.Names}}__{{.Image}}" --filter="name=$1"  | sed  's/docker\.elastic\.co\///g' | sed 's/[\:\.\/]/_/g' `) 
+        		logNames=(`docker ps -a --format "{{.ID}}__{{.Names}}__{{.Image}}" --filter="name=$1"  | sed  's/docker\.elastic\.co\///g' | sed 's/[\:\.\/]/_/g' `)
 		#consider all containers
 		else
 			containersId=(`docker ps -a --format "{{.ID}}"`)
         		logNames=(`docker ps -a --format "{{.ID}}__{{.Names}}__{{.Image}}"  | sed  's/docker\.elastic\.co\///g' | sed 's/[\:\.\/]/_/g' `)
-	fi			
-	
+	fi
+
 	print_msg "Grabbing docker logs..." "INFO"
-	arrayLength=${#containersId[@]}	
+	arrayLength=${#containersId[@]}
 	local i=0
 	for ((; i<$arrayLength; i++))
 	do
 		print_msg "Grabbing logs for containerId [${containersId[$i]}]" "INFO"
-		docker logs ${containersId[$i]} > $docker_logs_folder/${logNames[$i]}-container.log 2>&1
+		docker logs --since 72h ${containersId[$i]} > $docker_logs_folder/${logNames[$i]}-container.log 2>&1
 	done
 
 	print_msg "Grabbing docker ps..." "INFO"
@@ -216,10 +216,10 @@ do_http_request(){
 	args=$5
 	output_file=$6
 
-	#build request  
+	#build request
         request="curl -s -X$method -u $user:$password $protocol://$ece_host:$ece_port$path -o $output_file"
 
-	#validation 
+	#validation
 	validate_http_creds
 	if [[ ! -z $missing_creds ]]
 		then
@@ -252,9 +252,9 @@ process_action(){
 				then print_msg "cannot fetch cluster plan activity without specifying credentials" "WARN"
 				else
 					if [ -n $cluster_id ]
-						then 
+						then
 							create_folders plan
-							do_http_request GET http /api/v1/clusters/elasticsearch/$cluster_id/plan/activity $ece_port "" $docker_folder/plan/plan_$cluster_id.json	
+							do_http_request GET http /api/v1/clusters/elasticsearch/$cluster_id/plan/activity $ece_port "" $docker_folder/plan/plan_$cluster_id.json
 						else
 							print_msg "cannot fetch cluster plan activity without specifying a cluster id. Use option -c|--cluster to specify a cluster ID"	"WARN"
 					fi
@@ -263,11 +263,11 @@ process_action(){
 			cluster_info)
 			validate_http_creds
 			if [[ -n $missing_creds ]]
-                                then print_msg "cannot fetch cluster info plan without specifying credentials" "WARN"	
+                                then print_msg "cannot fetch cluster info plan without specifying credentials" "WARN"
 				else
 					if [ -n $cluster_id ]
                                 		then
-                                        		create_folders cluster_info 
+                                        		create_folders cluster_info
                                         		do_http_request GET http "/api/v1/clusters/elasticsearch/$cluster_id" $ece_port "?show_metadata=true&show_plans=true" $docker_folder/cluster_info/cluster_info_$cluster_id.json
                                 		else
                                         		print_msg "cannot fetch cluster info without specifying a cluster id. Use option -c|--cluster to specify a cluster ID" "WARN"
@@ -290,7 +290,7 @@ print_msg(){
 	#$2 sev
 	local sev=
 	if [ -n $2 ]
-		then 
+		then
 			sev="[$2]"
 	fi
 	echo "`date` $sev:  $1"
@@ -307,8 +307,8 @@ get_fs_permissions(){
 # no arguments -> show help
 if [ "$#" -eq 0 ]; then
 	show_help
-# arguments - parse them 
-else 
+# arguments - parse them
+else
 	while :; do
 	    	case $1 in
 	            -s|--system)
@@ -329,7 +329,7 @@ else
 		    if [ -z "$2" ]; then
                         die 'ERROR: "-o|--output-path" requires a valid full filesystem path'
                         else
-                    		output_path=$2 
+                    		output_path=$2
 				diag_folder=$output_path/$diag_name
 				elastic_folder=$diag_folder/elastic
 				docker_folder=$diag_folder/docker
@@ -412,9 +412,9 @@ fi
 
 print_msg "ECE Diagnostics" "INFO"
 sleep 1
-# go through identified actions and execute 
+# go through identified actions and execute
 if [ -z "$actions" ]
-	then 
+	then
 		: #do nothing
 	else
 		actions=($actions)
@@ -422,7 +422,7 @@ if [ -z "$actions" ]
 
 		for ((i=0; i<$actionsLength; i++))
         		do
-        			process_action ${actions[$i]} 
+        			process_action ${actions[$i]}
 		done
 
 fi


### PR DESCRIPTION
The diagnostic collected can be very large due to collect all logs from docker. This adds `--since 72h` to limit the period of time returned from `docker logs`.