### PR TITLE
Add `zookeeper` action which leverages found-shell tree exported to include ZK (ciphered) contents in the output bundle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options:
 -d|--docker #collects docker information
 -zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents
 -zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)
--zk-excluded|--zookeeper-excluded <excluded_paths> #optional, coma separated list of sub-trees to exclude in the bundle
+-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle
 -sp|--storage-path #overrides storage path (default:/mnt/data/elastic). Works in conjunction with -s|--system
 -o|--output-path #Specifies the output directory to dump the diagnostic bundles (default:/tmp)
 -c|--cluster <clusterID> #collects cluster plan and info for a given cluster (user/pass required). Also restricts -d|--docker action to a specific cluster

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -213,9 +213,7 @@ encrypt_file(){
         public_key_file=$1
         target_file=$2
         
-        temp_keyring=/tmp/$(date +%s%N)_pgp
-
-        mkdir $temp_keyring
+        temp_keyring=$(mktemp -d)
 
         gpg2 --homedir $temp_keyring --import $public_key_file
 

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -245,6 +245,14 @@ get_zookeeper(){
                         excluded_nodes=","
         fi
 
+        # Check that the current ECE version supports ZK dumps
+        docker run --rm $(docker inspect -f '{{ .Config.Image }}' frc-directors-director)  ls /elastic_cloud_apps/shell/scripts/dumpZkContents.sc;
+
+        if [ "$?" -ne "0" ];
+                then
+                        die "ERROR: ECE Version 2.5 or higher is required"
+        fi
+
         # Note that this is the directory (simbling to $elastic_folder) which will contain the clear temporary
         # ZK bundle in clear text prior to encryption. It will be deleted automatically.
         zookeeper_cleartext_folder=$(mktemp -d $elastic_folder/../zookeeper_dump_temporary.XXXX)

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -39,9 +39,9 @@ create_folders(){
 			cluster_info)
 			mkdir -p $docker_folder/cluster_info/
 			;;
-                        zookeeper)
-                        mkdir -p $zookeeper_folder
-                        ;;    
+			zookeeper)
+			mkdir -p $zookeeper_folder
+			;;
             		--) # End of all options.
             		shift
 			break
@@ -89,9 +89,9 @@ show_help(){
 	echo "-x|--port <port> #Specifies ECE port (default:12400)"
 	echo "-s|--system #collects elastic logs and system information"
 	echo "-d|--docker #collects docker information"
-        echo "-zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents"
-        echo "-zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)"
-        echo "-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, coma separated list of sub-trees to exclude in the bundle"
+	echo "-zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents"
+	echo "-zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)"
+	echo "-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, coma separated list of sub-trees to exclude in the bundle"
 	echo "-sp|--storage-path #overrides storage path (default:/mnt/data/elastic). Works in conjunction with -s|--system"
 	echo "-o|--output-path #Specifies the output directory to dump the diagnostic bundles (default:/tmp)"
 	echo "-c|--cluster <clusterID> #collects cluster plan and info for a given cluster (user/pass required). Also restricts -d|--docker action to a specific cluster"
@@ -235,7 +235,7 @@ get_zookeeper(){
         if [ -n "$2" ]
                 #Path for sub-tree root has been passed
                 then
-                        root_node=$2
+                    	root_node=$2
         fi
 
         if [ -n "$3" ]
@@ -259,7 +259,7 @@ get_zookeeper(){
         #Cipher dump file and remove the one in clear text
 
         # gpg2 --recipient-file $public_key_path -e $zookeeper_folder/zkdump.zip #Ideally we'd use this but it requires a version not so ubiquitous.
-        encrypt_file $public_key_path $zookeeper_folder/zkdump.zip
+        encrypt_file $public_key_path $zookeeper_folder/zkdump.zip;
         encryption_result=$?
         
         rm $zookeeper_folder/zkdump.zip

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -91,7 +91,7 @@ show_help(){
 	echo "-d|--docker #collects docker information"
 	echo "-zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents"
 	echo "-zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)"
-	echo "-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, coma separated list of sub-trees to exclude in the bundle"
+	echo "-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle"
 	echo "-sp|--storage-path #overrides storage path (default:/mnt/data/elastic). Works in conjunction with -s|--system"
 	echo "-o|--output-path #Specifies the output directory to dump the diagnostic bundles (default:/tmp)"
 	echo "-c|--cluster <clusterID> #collects cluster plan and info for a given cluster (user/pass required). Also restricts -d|--docker action to a specific cluster"

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -253,7 +253,7 @@ get_zookeeper(){
                         die "ERROR: ECE Version 2.5 or higher is required"
         fi
 
-        # Note that this is the directory (simbling to $elastic_folder) which will contain the clear temporary
+        # Note that this is the directory (sibling to $elastic_folder) which will contain the clear temporary
         # ZK bundle in clear text prior to encryption. It will be deleted automatically.
         zookeeper_cleartext_folder=$(mktemp -d $elastic_folder/../zookeeper_dump_temporary.XXXX)
 


### PR DESCRIPTION
Adding three new options to the diagnosis bundle generator:

- `zk|--zookeeper` Enables Zookeeper contents dump, it requires a path to a PGP public key (which Elastic engineers will provide and which its private counterpart is owned only by then). 
- `zk-path|--zookeeper-path` By default, the ZK contents dump is starts at the root of the repository (`/`). This option changes that behaviour allowing faster dumps by selecting paths support engineers might be interested in. 
- `zk-excluded|--zookeeper-excluded` Also, the default behaviour is to include all paths under the starting point (see point above). With this option, that behaviour can be changed as a, comma separated, list of concrete paths to avoid can be included. e.g: `/locks,/secrets/,/services/allocators` will remove these paths from the resulting bundle.

When `zk|--zookeeper` is present, the bundle will include `/elastic/zookeeper_dump/zkdump.zip.gpg` fie. It is encrypted using PGP and the key provided as a non-optional parameter. Only owners of the private key can open this file.

**Example of usage**

```bash
~/diagnostics.sh -zk ~/destination.key -zk-path /services -zk-excluded /services/allocators,/services/blueprint/states -d
```

**Internal**

This feature will only work with releases including this change: https://github.com/elastic/cloud/pull/42339

**This PR is ready to merge, I am holding it back until ECE release includes the infrastructure it requires (ECE >2.4)**