### PR TITLE
Limit system logs to files modified in last 72 hours

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -152,7 +152,7 @@ get_system(){
 			print_msg "'sar' command not found. Please install package 'sysstat' to collect extended system stats" "WARN"
 	fi
 	print_msg "Grabbing ECE logs" "INFO"
-	cd $storage_path && find . -type f -name *.log -mmin -4320 -exec cp --parents \{\} $elastic_folder \;
+	cd $storage_path && find . -type f -name "*.log" -mmin -4320 -exec cp --parents \{\} $elastic_folder \;
 	print_msg "Checking XFS info" "INFO"
 	[[ -x "$(type -P xfs_info)" ]] && xfs_info $storage_path > $elastic_folder/xfs_info.txt 2>&1
 }

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -152,7 +152,7 @@ get_system(){
 			print_msg "'sar' command not found. Please install package 'sysstat' to collect extended system stats" "WARN"
 	fi
 	print_msg "Grabbing ECE logs" "INFO"
-	cd $storage_path && find . -type f -name *.log -exec cp --parents \{\} $elastic_folder \;
+	cd $storage_path && find . -type f -name *.log -mmin -4320 -exec cp --parents \{\} $elastic_folder \;
 	print_msg "Checking XFS info" "INFO"
 	[[ -x "$(type -P xfs_info)" ]] && xfs_info $storage_path > $elastic_folder/xfs_info.txt 2>&1
 }


### PR DESCRIPTION
I ran into this massive over-retrieving of ECE logs today. This simple update stops the script from gathering log files from all eternity. The `-mmin -4320` translates into "Files modified within the last 72 hours"

Addresses the system half of https://github.com/elastic/ece-support-diagnostics/issues/15 since the Docker half is already complete.