### PR TITLE
ZK Dumps: Add sensitive/secret default exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
 -zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents
 -zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)
 -zk-excluded|--zookeeper-excluded <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle
+--zookeeper-excluded-insecure <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle WARNING: This options remove default filters aimed to avoid secrets and sensitive information leaks
 -sp|--storage-path #overrides storage path (default:/mnt/data/elastic). Works in conjunction with -s|--system
 -o|--output-path #Specifies the output directory to dump the diagnostic bundles (default:/tmp)
 -c|--cluster <clusterID> #collects cluster plan and info for a given cluster (user/pass required). Also restricts -d|--docker action to a specific cluster
@@ -88,6 +89,8 @@ This behavior can be constrained so the bundle:
 **Note**: How the list of excluded trees is a comma separated list of ZK paths.
 
 :warning: Eagle-eyed readers have probably noticed that this functionality **requires a PGP public key**. ECE Zookeeper contents contain potentially secret and/or sensitive information. For this reason, the bundle **will never contain ZK contents in clear text**. The output will contain a PGP encrypted file which can only be read by the owner of the private key counterpart for the provided key.
+
+:warning: By default, paths known to contain secrets or sensitive information have been excluded from the bundle. This protection can be deactivated, for those cases on which it is absolutely necessary, using the option `--zookeeper-excluded-insecure`. Please use this option with extreme caution and only when you are willing to show your passwords and certificates to the owner of the public PGP key.
 
 ### Using a custom storage path
 If you've installed ECE using a STORAGE_PATH different than default (`/mnt/data/elastic`), please make sure to pass the below flag to the diagnostics script:

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -19,7 +19,39 @@ actions=
 storage_path=/mnt/data/elastic
 pgp_destination_keypath=
 zk_root=/
-zk_excluded=
+
+zk_excluded=""
+# These path patterns are excluded by default for security and prinvacy reasons
+zk_excluded="$zk_excluded/container_sets/admin-consoles/containers/admin-console(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/admin-consoles/secrets,"
+zk_excluded="$zk_excluded/container_sets/blueprints/containers/blueprint(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/blueprints/secrets,"
+zk_excluded="$zk_excluded/container_sets/client-observers/containers/client-observer,"
+zk_excluded="$zk_excluded/container_sets/client-observers/secrets,"
+zk_excluded="$zk_excluded/container_sets/cloud-uis/containers/cloud-ui(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/cloud-uis/secrets,"
+zk_excluded="$zk_excluded/container_sets/constructors/containers/constructor(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/constructors/secrets,"
+zk_excluded="$zk_excluded/container_sets/curators/containers/curator(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/curators/secrets,"
+zk_excluded="$zk_excluded/container_sets/directors/containers/director(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/container_sets/directors/secrets,"
+zk_excluded="$zk_excluded/container_sets/proxies/containers/proxy(/inspect@[^/]+),"
+zk_excluded="$zk_excluded/container_sets/proxies/secrets,"
+zk_excluded="$zk_excluded/container_sets/proxies/containers/route-server(/inspect@[^/]+)?,"
+zk_excluded="$zk_excluded/services/runners/[^/]+/containers,"
+zk_excluded="$zk_excluded/clusters/[^/]+/secrets,"
+zk_excluded="$zk_excluded/services/allocators/[^/]+/[^/]+/instances,"
+zk_excluded="$zk_excluded/coordinators/secrets,"
+zk_excluded="$zk_excluded/secrets/certificates,"
+zk_excluded="$zk_excluded/services/adminconsole/secrets,"
+zk_excluded="$zk_excluded/services/proxies/secrets,"
+zk_excluded="$zk_excluded/services/cloudui/secrets,"
+zk_excluded="$zk_excluded/services/internaltls/config,"
+zk_excluded="$zk_excluded/clusters/[^/]+/app-auth-secrets,"
+zk_excluded="$zk_excluded/clusters/[^/]+/instances/instance-\d+/certificates,"
+zk_excluded="$zk_excluded/kibanas/[^/]+/instances/instance-\d+/certificates"
+
 
 create_folders(){
 	while :; do
@@ -92,6 +124,7 @@ show_help(){
 	echo "-zk|--zookeeper <path_to_dest_pgp_public_key> #enables ZK contents dump, requires a public PGP key to cipher the contents"
 	echo "-zk-path|--zookeeper-path <zk_path_to_include> #changes the path of the ZK sub-tree to dump (default: /)"
 	echo "-zk-excluded|--zookeeper-excluded <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle"
+	echo "--zookeeper-excluded-insecure <excluded_paths> #optional, comma separated list of sub-trees to exclude in the bundle WARNING: This options remove default filters aimed to avoid secrets and sensitive information leaks"
 	echo "-sp|--storage-path #overrides storage path (default:/mnt/data/elastic). Works in conjunction with -s|--system"
 	echo "-o|--output-path #Specifies the output directory to dump the diagnostic bundles (default:/tmp)"
 	echo "-c|--cluster <clusterID> #collects cluster plan and info for a given cluster (user/pass required). Also restricts -d|--docker action to a specific cluster"
@@ -510,9 +543,17 @@ else
                     fi
                     ;;
                     -zk-excluded|--zookeeper-excluded)
-                    # Sets Zookeeper exclusion paths, no exclussions by default
+                    # Sets Zookeeper exclusion paths
                     if [ -n "$2" ]; then
-                        zk_excluded=$2
+                        zk_excluded="$zk_excluded,$2"
+                        shift
+                    fi
+                    ;;
+                    --zookeeper-excluded-insecure)
+                    # Sets Zookeeper exclusion paths removing defaults Secret/Sensitive exclusions
+                    if [ -n "$2" ]; then
+                        print_msg "WARNING!! This option may lead to the inclusion of secrets and sensitive information within the bundle."
+                        zk_excluded="$2"
                         shift
                     fi
                     ;;

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -21,7 +21,7 @@ pgp_destination_keypath=
 zk_root=/
 
 zk_excluded=""
-# These path patterns are excluded by default for security and prinvacy reasons
+# These path patterns are excluded by default for security and privacy reasons
 zk_excluded="$zk_excluded/container_sets/admin-consoles/containers/admin-console(/inspect@[^/]+)?,"
 zk_excluded="$zk_excluded/container_sets/admin-consoles/secrets,"
 zk_excluded="$zk_excluded/container_sets/blueprints/containers/blueprint(/inspect@[^/]+)?,"

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -50,8 +50,8 @@ zk_excluded="$zk_excluded/services/cloudui/secrets,"
 zk_excluded="$zk_excluded/services/internaltls/config,"
 zk_excluded="$zk_excluded/clusters/[^/]+/app-auth-secrets,"
 zk_excluded="$zk_excluded/clusters/[^/]+/instances/instance-\d+/certificates,"
-zk_excluded="$zk_excluded/kibanas/[^/]+/instances/instance-\d+/certificates"
-
+zk_excluded="$zk_excluded/kibanas/[^/]+/instances/instance-\d+/certificates,"
+zk_excluded="$zk_excluded/[a-z]*/[^/]+/plans"
 
 create_folders(){
 	while :; do


### PR DESCRIPTION
Addresses https://github.com/elastic/cloud/issues/47469

This PR makes the bundle to include a set of excluded paths which can potentially contain secrets and sensitive information when generating ZK dumps.

Even though these dump bundles are encrypted by default, it is in our and the users of this tool interest to avoid having the recipients getting secrets they don't need for debugging purposes in most of the cases.

In the rare occasions when any of these paths are required, it is possible to use `--zookeeper-excluded-insecure`.

**Note:** This PR requires https://github.com/elastic/cloud/pull/47549 which will be included as part of ECE 2.5.