### PR TITLE
Added an OR to the find command for log files, to also grab *.ndjson

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -195,7 +195,7 @@ get_system(){
 			print_msg "'sar' command not found. Please install package 'sysstat' to collect extended system stats" "WARN"
 	fi
 	print_msg "Grabbing ECE logs" "INFO"
-	cd $storage_path && find . -type f -name "*.log" -mmin -4320 -exec cp --parents \{\} $elastic_folder \;
+	cd $storage_path && find . -type f \( -name "*.log" -o -name "*.ndjson" \) -mmin -4320 -exec cp --parents \{\} $elastic_folder \;
 	print_msg "Checking XFS info" "INFO"
 	[[ -x "$(type -P xfs_info)" ]] && xfs_info $storage_path > $elastic_folder/xfs_info.txt 2>&1
 }


### PR DESCRIPTION
files, which are used in ECE >=2.5.

Fixes #49

I tested on my home lab with ECE 2.5.0 running on Ubuntu 18.04.
Would be good if someone could double check with an older ECE and running on RHEL/CentOS. 