### PR TITLE
ERROR when bad cluster ID is specified

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -355,6 +355,8 @@ do_http_request(){
 				print_msg "${STDERR}" "ERROR"
 			elif grep -q "root.unauthenticated" $output_file; then
 				print_msg "The supplied authentication is invalid - please use ECE admin user/pass" "ERROR"
+			elif grep -q "clusters.cluster_not_found" $output_file; then
+				print_msg "Specified Cluster ID is invalid.  The Elasticsearch cluster ID can be found within the endpoint URL" "ERROR"
 			fi
         fi
 }


### PR DESCRIPTION
This is a small change that supplies the user with an error, and some help when a bad cluster ID is specified.    Without this change, something like the following is silently written to the output files:

```
{
  "errors": [{
    "code": "clusters.cluster_not_found",
    "message": "Cluster [085e247fc9974ea6bf61b515cc13d28] not found"
  }]
}
```

With this change, the following error is seen:

```
$ ./diagnostics.sh -a -c 085e247fc9974ea6bf61b515cc13d28 -u admin -p <x> -e x.x.x.x -x 12400
Fri 31 Jul 2020 13:05:51 EDT [INFO]:  ECE Diagnostics
Fri 31 Jul 2020 13:05:52 EDT [INFO]:  Calling [x.x.x.x:12400/api/v1/platform/infrastructure/allocators] with user[admin]
Fri 31 Jul 2020 13:05:53 EDT [INFO]:  Calling [x.x.x.x:12400/api/v1/clusters/elasticsearch/085e247fc9974ea6bf61b515cc13d28/plan/activity] with user[admin]
Fri 31 Jul 2020 13:05:55 EDT [ERROR]:  Supplied Cluster ID is invalid.  The Elasticsearch cluster ID can be found within the endpoint URL
Fri 31 Jul 2020 13:05:55 EDT [INFO]:  Calling [x.x.x.x:12400/api/v1/clusters/elasticsearch/085e247fc9974ea6bf61b515cc13d28] with user[admin]
Fri 31 Jul 2020 13:05:56 EDT [ERROR]:  Supplied Cluster ID is invalid.  The Elasticsearch cluster ID can be found within the endpoint URL
Fri 31 Jul 2020 13:05:56 EDT [INFO]:  Compressing diag file...
Fri 31 Jul 2020 13:05:56 EDT [INFO]:  Diag ready at /tmp/ece_diag_x.local_31_Jul_2020_13_05_51.tar.gz
Fri 31 Jul 2020 13:05:56 EDT [INFO]:  Cleaning temp files...
```