### PR TITLE
Add additional API calls for platform and clusters 

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -373,6 +373,8 @@ process_action(){
                         allocators)
                         create_folders allocators
                         do_http_request GET $protocol /api/v1/platform/infrastructure/allocators $ece_port "" $elastic_folder/allocators/allocators.json
+						do_http_request GET $protocol /api/v1/platform $ece_port "" $elastic_folder/allocators/platform.json
+						do_http_request GET $protocol /api/v1/clusters/elasticsearch $ece_port "" $elastic_folder/allocators/elasticsearch-clusters.json
                         ;;
 			plan)
 			validate_http_creds

--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -347,7 +347,7 @@ do_http_request(){
 		then
 			print_msg "Skipping HTTP request [ $path ] because of missing arguments [ $missing_creds ]" "WARN"
                 else
-			print_msg "Calling [$ece_host:$ece_port$path] with user[$user]" "INFO"
+			print_msg "Calling [$ece_host:$ece_port$path] with user [$user]" "INFO"
 			sleep 1
 			STDERR=`$request 2>&1`
 			if [ ! -s $output_file ]; then
@@ -372,7 +372,7 @@ process_action(){
                         ;;
                         allocators)
                         create_folders allocators
-                        do_http_request GET http /api/v1/platform/infrastructure/allocators $ece_port "" $elastic_folder/allocators/allocators.json
+                        do_http_request GET $protocol /api/v1/platform/infrastructure/allocators $ece_port "" $elastic_folder/allocators/allocators.json
                         ;;
 			plan)
 			validate_http_creds


### PR DESCRIPTION
This PR adds two additional API calls to the `--allocators` parameter. 

* [GET /api/v1/platform](https://www.elastic.co/guide/en/cloud-enterprise/current/get-platform.html)
* [GET /api/v1/clusters/elasticsearch](https://www.elastic.co/guide/en/cloud-enterprise/current/get-es-clusters.html)

Both of the APIs can be useful when debugging ECE issues as they give the engineer a better overview of the Platform and Clusters. 

While the cleaner approach would have been to rename the `--allocators` param to something more generic, I went for the most simple approach here and just added the two calls to the existing `-a|--allocators` parameter. 
Reason for this is that we are already planing to rewrite the ECE diag tool and thus it does not make much sense to do big changes.

In addition to the above, I've also fixed the hard coded `http` to actually respect the `--protocol` value. 