### PR TITLE
Added dmesg output

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -151,6 +151,7 @@ get_system(){
         top -n1 -b > $elastic_folder/top.txt
         ps -eaf > $elastic_folder/ps.txt
         df -h > $elastic_folder/df.txt
+        sudo dmesg --ctime > $elastic_folder/dmesg.txt
 
         #network
         sleep 1


### PR DESCRIPTION
Added `sudo dmesg --ctime` output as this can often help to detect disk / filesystem issues. 

I would have preferred to add `sudo dmesg --ctime --time-format iso` as this would align timestamps, but unfortunatly CentOS/RHEL 7 do not support this. 

Added it with `sudo`, as more recent distros require sudo to run dmesg. Should be fine as there are many other system commands executed with sudo already. 

Tested on:

- [x] CentOS 7
- [x] Ubuntu 18.04
- [x] Ubuntu 16.04
- [x] SLES 12 SP 5

Closes #24 
