### PR TITLE
increment version to 2.0.2 and check storage path regardless of -s

### DIFF
--- a/src/ece-diagnostics.sh
+++ b/src/ece-diagnostics.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ECE_DIAG_VERSION=2.0.1
+ECE_DIAG_VERSION=2.0.2
 
 setVariables(){
         #location of scripts

--- a/src/ece-diagnostics.sh
+++ b/src/ece-diagnostics.sh
@@ -426,7 +426,6 @@ process_action(){
         while :; do
                 case $1 in
                 system)
-                        verifyStoragePath
                         create_folders system
                         get_system
                         ;;
@@ -927,5 +926,7 @@ initiateLogFile(){
 setVariables
 
 parseParams "$@"
+
+verifyStoragePath
 
 runECEDiag


### PR DESCRIPTION
incrementing version to 2.0.2 to detect in case someone runs from source and ahead of next release
also fix issue with invalid storage path not auto-corrected when `-s` option is not used